### PR TITLE
feat/increase-frequency-of-schedule-2

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,10 +29,10 @@ functions:
     memorySize: 512
     timeout: 900
     events:
-      ## Schedule: Every day at 03:00 Eastern
+      ## Schedule: Every other hour
       - schedule:
           method: scheduler
-          rate: cron(0 3 * * ? *)
+          rate: cron(0 */2 * * ? *)
           timezone: America/New_York
 
 resources:


### PR DESCRIPTION
We are currently hitting code storage limits within AWS.
This prevents us from being able to deploy.
The clear-lambda-storage process is able to prevent those limits from being hit.
The current frequency of this process is not often enough.
This PR increases the frequency of this process.
